### PR TITLE
Add Log metadata

### DIFF
--- a/ctlog/ctlog.go
+++ b/ctlog/ctlog.go
@@ -1,3 +1,17 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package ctlog contains data structures and methods to do with CT Log metadata
 // that is needed by the monitor.
 //

--- a/ctlog/ctlog.go
+++ b/ctlog/ctlog.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/certificate-transparency-go/logid"
 )
 
-// Log represents a CT Log and contains the Log metadata needed by the monitor.
+// Log contains metadata about a CT Log that is needed by the monitor.
 type Log struct {
 	ID        logid.LogID
 	Name      string

--- a/ctlog/ctlog.go
+++ b/ctlog/ctlog.go
@@ -20,7 +20,6 @@ package ctlog
 
 import (
 	"crypto"
-	"fmt"
 
 	ct "github.com/google/certificate-transparency-go"
 	"github.com/google/certificate-transparency-go/logid"
@@ -42,11 +41,11 @@ type Log struct {
 func New(url, name, b64PubKey string) (*Log, error) {
 	id, err := logid.FromPubKeyB64(b64PubKey)
 	if err != nil {
-		return nil, fmt.Errorf("logid.FromPubKeyB64(): %s", err)
+		return nil, err
 	}
 	pk, err := ct.PublicKeyFromB64(b64PubKey)
 	if err != nil {
-		return nil, fmt.Errorf("ct.PublicKeyFromB64(): %s", err)
+		return nil, err
 	}
 	return &Log{
 		ID:        id,

--- a/ctlog/ctlog.go
+++ b/ctlog/ctlog.go
@@ -1,0 +1,43 @@
+// Package ctlog contains data structures and methods to do with CT Log metadata
+// that is needed by the monitor.
+//
+// TODO(katjoyce): Try to come up with a better package name.
+package ctlog
+
+import (
+	"crypto"
+	"fmt"
+
+	ct "github.com/google/certificate-transparency-go"
+	"github.com/google/certificate-transparency-go/logid"
+)
+
+// Log represents a CT Log and contains the Log metadata needed by the monitor.
+type Log struct {
+	ID        logid.LogID
+	Name      string
+	URL       string
+	PublicKey crypto.PublicKey
+}
+
+// New creates a Log structure, populating the fields appropriately.
+//
+// TODO(katjoyce): replace this implementation with something less hacky that
+// takes log details from a log list struct based on the new Log list JSON
+// schema.
+func New(url, name, b64PubKey string) (*Log, error) {
+	id, err := logid.FromPubKeyB64(b64PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("logid.FromPubKeyB64(): %s", err)
+	}
+	pk, err := ct.PublicKeyFromB64(b64PubKey)
+	if err != nil {
+		return nil, fmt.Errorf("ct.PublicKeyFromB64(): %s", err)
+	}
+	return &Log{
+		ID:        id,
+		Name:      name,
+		URL:       url,
+		PublicKey: pk,
+	}, nil
+}

--- a/storage/print/print.go
+++ b/storage/print/print.go
@@ -25,13 +25,14 @@ import (
 	"log"
 
 	"github.com/google/certificate-transparency-monitor/apicall"
+	"github.com/google/certificate-transparency-monitor/ctlog"
 )
 
 // Storage implements the storage interfaces needed by the CT monitor.
 type Storage struct{}
 
 // WriteAPICall simply prints the API Call passed to it.
-func (s *Storage) WriteAPICall(ctx context.Context, apiCall *apicall.APICall) error {
-	log.Println(apiCall.String())
+func (s *Storage) WriteAPICall(ctx context.Context, l *ctlog.Log, apiCall *apicall.APICall) error {
+	log.Printf("%s: %s", l.Name, apiCall.String())
 	return nil
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -20,10 +20,11 @@ import (
 	"context"
 
 	"github.com/google/certificate-transparency-monitor/apicall"
+	"github.com/google/certificate-transparency-monitor/ctlog"
 )
 
 // APICallWriter is an interface for storing individual calls to CT API
 // endpoints.
 type APICallWriter interface {
-	WriteAPICall(ctx context.Context, apiCall *apicall.APICall) error
+	WriteAPICall(ctx context.Context, l *ctlog.Log, apiCall *apicall.APICall) error
 }


### PR DESCRIPTION
Purpose is so that the WriteAPICalls interface is also passed information
about which Log the APICall is for, so implementations are able to store
the api call information for the correct Log.